### PR TITLE
[wip] Resolve errors on cache clear

### DIFF
--- a/lcache.install
+++ b/lcache.install
@@ -92,17 +92,6 @@ function lcache_schema() {
 }
 
 /**
- * Implements hook_install().
- */
-function lcache_install() {
-  db_query('
-    ALTER TABLE {lcache_tags}
-    ADD CONSTRAINT {lcache_tags_event_id}
-    FOREIGN KEY (event_id) REFERENCES {lcache_events} (event_id)
-  ');
-}
-
-/**
  * Implements hook_uninstall().
  */
 function lcache_uninstall() {


### PR DESCRIPTION
I'm working on profiling this module and I have a lot of errors in my log related to failed cache clears.

```
#0 /srv/bindings/449a177241d6495d928f6617bcc6c661/code/vendor/lcache/lcache/src/DatabaseL2.php(54): PDOStatement->execute()
#1 /srv/bindings/449a177241d6495d928f6617bcc6c661/code/vendor/lcache/lcache/src/DatabaseL2.php(67): LCache\DatabaseL2->pruneReplacedEvents()
#2 [internal function]: LCache\DatabaseL2->__destruct()
#3 {main}
  thrown in /srv/bindings/449a177241d6495d928f6617bcc6c661/code/vendor/lcache/lcache/src/DatabaseL2.php on line 54
[09-Sep-2016 12:05:50 UTC] Uncaught PHP Exception PDOException: "SQLSTATE[23000]: Integrity constraint violation: 1451 Cannot delete or update a parent row: a foreign key constraint fails ("pantheon"."lcache_tags", CONSTRAINT "lcache_tags_event_id" FOREIGN KEY ("event_id") REFERENCES "lcache_events" ("event_id"))" at /srv/bindings/449a177241d6495d928f6617bcc6c661/code/vendor/lcache/lcache/src/DatabaseL2.php line 255
```

This module adds a constraint on foreign keys that is not present in the Drupal 7 or Drupal 8 version. @davidstrauss Should we be removing the constraint or altering the lcache library so that deletions from the events table also trigger deletions from the tags table?
