### PR TITLE
Set overhead variable

### DIFF
--- a/src/BackendFactory.php
+++ b/src/BackendFactory.php
@@ -41,7 +41,7 @@ class BackendFactory {
       $l1 = new \LCache\APCuL1();
     }
     $l2 = new \LCache\DatabaseL2($this->getPdoHandle());
-    $this->integrated = new \LCache\Integrated($l1, $l2);
+    $this->integrated = new \LCache\Integrated($l1, $l2, 100);
     $this->integrated->synchronize();
   }
 


### PR DESCRIPTION
In merging github and drupal.org repos yesterday I lost this change that @davidstrauss made on drupal.org. It uses some light machine learning that was added to LCache in https://github.com/lcache/lcache/pull/24

@davidstrauss, it seems like this argument should be configurable to some degree, perhaps making it an argument to the service, `cache.backend.lcache`. The vast, vast majority of people using the module won't need to know that configurability is there. But it's a number we could tweak to find optimal performance. `100` is a somewhat arbitrary choice here, yes?
