### PR TITLE
Push to Drupal.org

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -67,4 +67,23 @@ test:
     - ./vendor/bin/phpcs --report=full --extensions=php,module,inc,theme,info --standard=vendor/drupal/coder/coder_sniffer/Drupal/ --ignore=vendor .
     - cd $DOCROOT && /home/ubuntu/.phpenv/shims/php  core/scripts/run-tests.sh  --url  $SERVER  --module lcache    --php  /home/ubuntu/.phpenv/shims/php --verbose  --color
     
-
+deployment:
+  feature:
+    branch: 8.x-1.x
+    commands:
+      # Make sure the full history from GitHub is present. If it is not,
+      # the push to drupal.org will fail.
+      - git fetch --unshallow
+      - git remote add drupalorg stevector@git.drupal.org:project/lcache.git
+      - git fetch drupalorg
+      - git push  drupalorg $CIRCLE_BRANCH
+  release:
+    tag: /8.x-.*/
+    owner: pantheon-systems
+    commands:
+      # Make sure the full history from GitHub is present. If it is not,
+      # the push to drupal.org will fail.
+      - git fetch --unshallow
+      - git remote add drupalorg stevector@git.drupal.org:project/lcache.git
+      - git fetch drupalorg
+      - git push  drupalorg --tags

--- a/circle.yml
+++ b/circle.yml
@@ -79,7 +79,7 @@ deployment:
       - git push  drupalorg $CIRCLE_BRANCH
   release:
     tag: /8.x-.*/
-    owner: pantheon-systems
+    owner: lcache
     commands:
       # Make sure the full history from GitHub is present. If it is not,
       # the push to drupal.org will fail.


### PR DESCRIPTION
Automatically push the 8.x-1.x branch and 8.x tags to Drupal.org to simplify releases.
